### PR TITLE
portability: inline is mostly ignored in modern compilers

### DIFF
--- a/quickjs.h
+++ b/quickjs.h
@@ -41,7 +41,7 @@ extern "C" {
 #else
 #define js_likely(x)     (x)
 #define js_unlikely(x)   (x)
-#define js_force_inline  __forceinline
+#define js_force_inline  inline
 #define __js_printf_like(a, b)
 #endif
 


### PR DESCRIPTION
* this patch fixes the build on not using gcc/clang/msvc