### PR TITLE
add JS_NewTwoByteString() quickjs-ng feature

### DIFF
--- a/quickjs.c
+++ b/quickjs.c
@@ -4052,19 +4052,19 @@ JSValue JS_NewStringLen(JSContext *ctx, const char *buf, size_t buf_len)
 
 JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
 {
-	JSString *str;
+    JSString *str;
     if (!len)
         return JS_AtomToString(ctx, JS_ATOM_empty_string);
-	for (int i = 0; i < len; i++)
-		if (buf[i] >= 128)
-			return js_new_string16(ctx, buf, len);
-	str = js_alloc_string(ctx, len, 0);
-	if (!str)
-		return JS_EXCEPTION;
-	for (int i = 0; i < len; i++)
-		str->u.str8[i] = buf[i];
-	str->u.str8[len] = '\0';
-	return JS_MKPTR(JS_TAG_STRING, str);
+    for (int i = 0; i < len; i++)
+        if (buf[i] >= 128)
+            return js_new_string16(ctx, buf, len);
+    str = js_alloc_string(ctx, len, 0);
+    if (!str)
+        return JS_EXCEPTION;
+    for (int i = 0; i < len; i++)
+        str->u.str8[i] = buf[i];
+    str->u.str8[len] = '\0';
+    return JS_MKPTR(JS_TAG_STRING, str);
 }
 
 static JSValue JS_ConcatString3(JSContext *ctx, const char *str1,

--- a/quickjs.c
+++ b/quickjs.c
@@ -4054,7 +4054,7 @@ JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
 {
     if (!len)
         return JS_AtomToString(ctx, JS_ATOM_empty_string);
-    return js_new_string16_len(ctx, buf, len);
+    return js_new_string16(ctx, buf, len);
 }
 
 static JSValue JS_ConcatString3(JSContext *ctx, const char *str1,

--- a/quickjs.c
+++ b/quickjs.c
@@ -4050,6 +4050,13 @@ JSValue JS_NewStringLen(JSContext *ctx, const char *buf, size_t buf_len)
     return JS_EXCEPTION;
 }
 
+JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
+{
+    if (!len)
+        return js_empty_string(ctx->rt);
+    return js_new_string16_len(ctx, buf, len);
+}
+
 static JSValue JS_ConcatString3(JSContext *ctx, const char *str1,
                                 JSValue str2, const char *str3)
 {

--- a/quickjs.c
+++ b/quickjs.c
@@ -4053,7 +4053,7 @@ JSValue JS_NewStringLen(JSContext *ctx, const char *buf, size_t buf_len)
 JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
 {
     if (!len)
-        return js_empty_string(ctx->rt);
+        return JS_AtomToString(ctx, JS_ATOM_empty_string);
     return js_new_string16_len(ctx, buf, len);
 }
 

--- a/quickjs.c
+++ b/quickjs.c
@@ -4052,9 +4052,19 @@ JSValue JS_NewStringLen(JSContext *ctx, const char *buf, size_t buf_len)
 
 JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len)
 {
+	JSString *str;
     if (!len)
         return JS_AtomToString(ctx, JS_ATOM_empty_string);
-    return js_new_string16(ctx, buf, len);
+	for (int i = 0; i < len; i++)
+		if (buf[i] >= 128)
+			return js_new_string16(ctx, buf, len);
+	str = js_alloc_string(ctx, len, 0);
+	if (!str)
+		return JS_EXCEPTION;
+	for (int i = 0; i < len; i++)
+		str->u.str8[i] = buf[i];
+	str->u.str8[len] = '\0';
+	return JS_MKPTR(JS_TAG_STRING, str);
 }
 
 static JSValue JS_ConcatString3(JSContext *ctx, const char *str1,

--- a/quickjs.h.in
+++ b/quickjs.h.in
@@ -841,6 +841,7 @@ int JS_ToInt64Ext(JSContext *ctx, int64_t *pres, JSValueConst val);
 
 JSValue JS_NewStringLen(JSContext *ctx, const char *str1, size_t len1);
 JSValue JS_NewString(JSContext *ctx, const char *str);
+JSValue JS_NewTwoByteString(JSContext *ctx, const uint16_t *buf, size_t len);
 JSValue JS_NewAtomString(JSContext *ctx, const char *str);
 JSValue JS_ToString(JSContext *ctx, JSValueConst val);
 JSValue JS_ToPropertyKey(JSContext *ctx, JSValueConst val);


### PR DESCRIPTION
For speed up readUtf16String.

I viewd the code of readUtf16String in frida-gum, found that is g_utf16_to_utf8 then JS_NewString.

So I add JS_NewTwoByteString for direct transfer UTF-16 to JS string rather than UTF-16 to UTF-8 to JS string because JS string is UTF-16.

https://github.com/frida/frida-gum/pull/1067